### PR TITLE
ESTV-27: change user agent

### DIFF
--- a/amazon-exoplayer/src/main/java/com/brentvatne/exoplayer/DataSourceUtil.java
+++ b/amazon-exoplayer/src/main/java/com/brentvatne/exoplayer/DataSourceUtil.java
@@ -35,7 +35,7 @@ public class DataSourceUtil {
 
     public static String getUserAgent(ReactContext context) {
         if (userAgent == null) {
-            userAgent = Util.getUserAgent(context, "ReactNativeVideo");
+            userAgent = Util.getUserAgent(context, "EurosportPlayer/Android_TV");
         }
         return userAgent;
     }


### PR DESCRIPTION
We need to send through a bespoke `user-agent` for ExoPlayer content:

`EurosportPlayer/Android_TV`
`EurosportPlayer/Fire_TV`

Please note that when building release containers we will now need to make this change to ensure that the builds have the correct `user-agent` applied.

FYI @DavidFlores24 